### PR TITLE
Fix specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -96,6 +98,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/spec/app.rb
+++ b/spec/app.rb
@@ -2,16 +2,12 @@
 
 require "sinatra"
 class App < Sinatra::Base
-  get "/" do
-    "<html><body><h1>Root Page</h1></body></html>"
-  end
-
   get "/next" do
     "<html><body><h1>Next Page</h1></body></html>"
   end
 
   get "/with_a_image" do
-    %(<html><body><img src='/heavy_image.png'><a href='/next'>Next Page</a></body></html>)
+    erb :with_a_image
   end
 
   get "/without_images" do

--- a/spec/capybara/wait_before_click_spec.rb
+++ b/spec/capybara/wait_before_click_spec.rb
@@ -2,16 +2,14 @@
 
 RSpec.describe Capybara::WaitBeforeClick, type: :feature do
   it "wait a image before click" do
-    visit "/" # for booting chrome and puma
-
-    without_images_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     visit "/without_images"
+    without_images_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     click_link "Next Page"
     without_images_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     expect(page).to have_css("h1", text: "Next Page")
 
-    with_a_image_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     visit "/with_a_image"
+    with_a_image_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     click_link "Next Page"
     with_a_image_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     expect(page).to have_css("h1", text: "Next Page")

--- a/spec/views/with_a_image.erb
+++ b/spec/views/with_a_image.erb
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <script type="text/javascript">
+      setTimeout(() => {
+        const img = document.createElement('img');
+        img.setAttribute('src', '/heavy_image.png');
+        document.body.prepend(img);
+      }, 1)
+    </script>
+  </head>
+  <body>
+    <a href='/next'>Next Page</a>
+  </body>
+</html>


### PR DESCRIPTION
`visit` blocks until the image is rendered, so it was not properly checking that it was waiting as expected. The correct check is now possible by displaying the image asynchronously.
