### PR TITLE
wait before hover

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/lib/capybara/wait_before_click.rb
+++ b/lib/capybara/wait_before_click.rb
@@ -30,6 +30,11 @@ module Capybara
       super
     end
 
+    def hover
+      _wait_for_image_loading
+      super
+    end
+
     def _logger
       @_logger ||= if defined?(Rails)
                      Rails.logger

--- a/spec/app.rb
+++ b/spec/app.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "sinatra"
+require "securerandom"
+
 class App < Sinatra::Base
   get "/next" do
     "<html><body><h1>Next Page</h1></body></html>"
@@ -14,7 +16,7 @@ class App < Sinatra::Base
     %(<html><body><a href='/next'>Next Page</a></body></html>)
   end
 
-  get "/heavy_image.png" do
+  get "/heavy_image/*.png" do
     sleep 2
     send_file("spec/heavy_image.png")
   end

--- a/spec/capybara/wait_before_click_spec.rb
+++ b/spec/capybara/wait_before_click_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe Capybara::WaitBeforeClick, type: :feature do
 
     expect(without_images_duration + 2).to be_within(0.2).of(with_a_image_duration)
   end
+
+  it "wait a image before hover" do
+    visit "/without_images"
+    without_images_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    find_link("Next Page").hover
+    without_images_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    visit "/with_a_image"
+    with_a_image_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    find_link("Next Page").hover
+    with_a_image_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    without_images_duration = without_images_after - without_images_before
+    with_a_image_duration = with_a_image_after - with_a_image_before
+
+    expect(without_images_duration + 2).to be_within(0.2).of(with_a_image_duration)
+  end
 end

--- a/spec/views/with_a_image.erb
+++ b/spec/views/with_a_image.erb
@@ -3,7 +3,7 @@
     <script type="text/javascript">
       setTimeout(() => {
         const img = document.createElement('img');
-        img.setAttribute('src', '/heavy_image.png');
+        img.setAttribute('src', '/heavy_image/<%= SecureRandom.hex(10) %>.png');
         document.body.prepend(img);
       }, 1)
     </script>


### PR DESCRIPTION
When hovering over a particular DOM element to display an icon and then clicking on that icon, the icon will be hidden and the click may fail if you don’t wait for loading images before hovering. This problem is now resolved automatically.

The test fails because chrome caches an image, so I made it so that it generates a random path every time.

I tried https://stackoverflow.com/questions/29988227/disable-cache-in-selenium-chrome-driver but I couldn't turn off the cache.
