### PR TITLE
Make wait image specs deterministic

### DIFF
--- a/spec/app.rb
+++ b/spec/app.rb
@@ -4,8 +4,33 @@ require "sinatra"
 require "securerandom"
 
 class App < Sinatra::Base
+  @events = {}
+  @events_mutex = Mutex.new
+
+  class << self
+    def reset_events!
+      @events_mutex.synchronize { @events = {} }
+    end
+
+    def events
+      @events_mutex.synchronize { @events.dup }
+    end
+
+    def record_event(name)
+      @events_mutex.synchronize do
+        @events[name] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+
   get "/next" do
+    App.record_event(:next_requested_at)
     "<html><body><h1>Next Page</h1></body></html>"
+  end
+
+  get "/hovered" do
+    App.record_event(:hover_requested_at)
+    status 204
   end
 
   get "/with_a_image" do
@@ -17,8 +42,11 @@ class App < Sinatra::Base
   end
 
   get "/heavy_image/*.png" do
+    App.record_event(:image_requested_at)
     sleep 2
-    send_file("spec/heavy_image.png")
+    App.record_event(:image_finished_at)
+    content_type "image/png"
+    File.binread("spec/heavy_image.png")
   end
 
   run! if app_file == $PROGRAM_NAME

--- a/spec/capybara/wait_image_spec.rb
+++ b/spec/capybara/wait_image_spec.rb
@@ -1,38 +1,35 @@
 # frozen_string_literal: true
 
 RSpec.describe Capybara::WaitImage, type: :feature do
+  before do
+    App.reset_events!
+  end
+
   it "wait a image before click" do
-    visit "/without_images"
-    without_images_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    click_link "Next Page"
-    without_images_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    expect(page).to have_css("h1", text: "Next Page")
-
     visit "/with_a_image"
-    with_a_image_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    wait_until_event(:image_requested_at)
+    expect(App.events).not_to have_key(:image_finished_at)
+
     click_link "Next Page"
-    with_a_image_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     expect(page).to have_css("h1", text: "Next Page")
 
-    without_images_duration = without_images_after - without_images_before
-    with_a_image_duration = with_a_image_after - with_a_image_before
-
-    expect(without_images_duration + 2).to be_within(0.5).of(with_a_image_duration)
+    expect(App.events.fetch(:next_requested_at)).to be >= App.events.fetch(:image_finished_at)
   end
 
   it "wait a image before hover" do
-    visit "/without_images"
-    without_images_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    find_link("Next Page").hover
-    without_images_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     visit "/with_a_image"
-    with_a_image_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    wait_until_event(:image_requested_at)
+    expect(App.events).not_to have_key(:image_finished_at)
+
     find_link("Next Page").hover
-    with_a_image_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-    without_images_duration = without_images_after - without_images_before
-    with_a_image_duration = with_a_image_after - with_a_image_before
+    wait_until_event(:hover_requested_at)
+    expect(App.events.fetch(:hover_requested_at)).to be >= App.events.fetch(:image_finished_at)
+  end
 
-    expect(without_images_duration + 2).to be_within(0.5).of(with_a_image_duration)
+  def wait_until_event(name)
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      sleep 0.01 until App.events.key?(name)
+    end
   end
 end

--- a/spec/views/with_a_image.erb
+++ b/spec/views/with_a_image.erb
@@ -1,14 +1,14 @@
 <html>
-  <head>
-    <script type="text/javascript">
-      setTimeout(() => {
-        const img = document.createElement('img');
-        img.setAttribute('src', '/heavy_image/<%= SecureRandom.hex(10) %>.png');
-        document.body.prepend(img);
-      }, 1)
-    </script>
-  </head>
   <body>
-    <a href='/next'>Next Page</a>
+    <a href="/next" onmouseover="fetch('/hovered')">Next Page</a>
+    <script type="text/javascript">
+      window.addEventListener('load', () => {
+        setTimeout(() => {
+          const img = document.createElement('img');
+          img.setAttribute('src', '/heavy_image/<%= SecureRandom.hex(10) %>.png');
+          document.body.prepend(img);
+        }, 0);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
The existing feature specs compared elapsed wall-clock time between pages with and without images. That made the tests sensitive to CI load, browser scheduling, and the polling interval inside Capybara::WaitImage, so occasional failures did not necessarily indicate a behavior regression.

This change records server-side events for the image request, image completion, click navigation, and hover side effect. The page now adds the image after load, and the specs wait until the image request has started while confirming it has not finished before triggering click or hover. They then assert that the user interaction reaches the app only after the image has completed loading.

Keeping the assertion based on event order preserves the intent of the tests while avoiding a fragile fixed-duration comparison. No related issue was referenced.