### PR TITLE
Add RubyGems release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,9 +25,11 @@ jobs:
           - '4.0'
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,32 @@
+name: Release new version to RubyGems.org
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
+        with:
+          ruby-version: ruby
+
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
+
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This repository did not have the manual GitHub Actions path used in willnet/gimei for publishing a gem and creating the matching GitHub release. Adding the workflow makes releases reproducible from CI instead of relying on a local release command.

The release job uses RubyGems trusted publishing via the GitHub OIDC token, then creates release notes from the pushed tag. The workflow keeps checkout credentials disabled and pins actions to commit SHAs so the existing zizmor blanket policy passes.

While adding the new workflow, the existing CI workflow also needed the same hardening because zizmor checks all workflows together. It now has read-only contents permission, disabled checkout credential persistence, and pinned action references.