### PR TITLE
Install bundle dependencies before releasing gem

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: ruby
+          bundler-cache: true
 
       - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
 


### PR DESCRIPTION
The RubyGems release workflow runs rubygems/release-gem, which invokes the gem task through Bundler. Unlike the normal CI workflow, the release job only selected a Ruby version and did not run Bundler's install/cache setup first.

As a result, the workflow could reach bundle exec rake with only the locally available gems and fail before releasing when development dependencies such as puma were missing from the runner.

Enable ruby/setup-ruby's bundler-cache option in the release job so the locked bundle is installed before rubygems/release-gem runs. This keeps the release path aligned with CI without adding a separate bundle install step.